### PR TITLE
Migrate to Python 3 and latest Flask + Improved IP detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Python compiled byte code
+*.pyc
+/build
+/dist
+
+# IDE files
+.idea
+*.iml
+*.ipr
+*.iws
+.settings
+.project
+.pydevproject
+.directory
+
+# Virtual environments
+venv*/
+.venv*/
+
+/.env

--- a/pyqrshare.egg-info/PKG-INFO
+++ b/pyqrshare.egg-info/PKG-INFO
@@ -8,7 +8,11 @@ Author-email: mirimmad17@gmail.com
 License: MIT
 Classifier: Development Status :: Beta
 Classifier: License :: OSI Approved :: MIT License
-Classifier: Programming Language :: Python :: 2.7
+Classifier: Programming Language :: Python :: 3
+Classifier: Programming Language :: Python :: 3.8
+Classifier: Programming Language :: Python :: 3.9
+Classifier: Programming Language :: Python :: 3.10
+Classifier: Programming Language :: Python :: 3.11
 Classifier: Topic :: File Sharing :: QRCode
 License-File: LICENSE
 Requires-Dist: netifaces

--- a/pyqrshare.egg-info/PKG-INFO
+++ b/pyqrshare.egg-info/PKG-INFO
@@ -1,4 +1,4 @@
-Metadata-Version: 1.1
+Metadata-Version: 2.1
 Name: pyqrshare
 Version: 1.0
 Summary: Lets you transfer files and directories from your computer to your mobile device by scanning a QR code right from the terminal
@@ -6,9 +6,11 @@ Home-page: http://github.com/mirimmad/pyqrshare
 Author: Mir Immad
 Author-email: mirimmad17@gmail.com
 License: MIT
-Description: UNKNOWN
-Platform: UNKNOWN
 Classifier: Development Status :: Beta
 Classifier: License :: OSI Approved :: MIT License
 Classifier: Programming Language :: Python :: 2.7
 Classifier: Topic :: File Sharing :: QRCode
+License-File: LICENSE
+Requires-Dist: netifaces
+Requires-Dist: Flask
+Requires-Dist: pyqrcode

--- a/pyqrshare.egg-info/SOURCES.txt
+++ b/pyqrshare.egg-info/SOURCES.txt
@@ -1,3 +1,5 @@
+LICENSE
+README.md
 setup.py
 pyqrshare/__init__.py
 pyqrshare/command_line.py

--- a/pyqrshare.egg-info/entry_points.txt
+++ b/pyqrshare.egg-info/entry_points.txt
@@ -1,3 +1,2 @@
 [console_scripts]
 pyqrshare = pyqrshare.command_line:main
-

--- a/pyqrshare/__init__.py
+++ b/pyqrshare/__init__.py
@@ -16,10 +16,13 @@ def check_args():
 
 
 def return_wlan0_ip():
-	try: 
-		ip = ni.ifaddresses('wlan0')[ni.AF_INET][0]['addr']
+	try:
+		wlan = next(filter(
+					lambda x: x.startswith("wlan") or x.startswith("wlp"),
+					ni.interfaces()))
+		ip = ni.ifaddresses(wlan)[ni.AF_INET][0]['addr']
 		return ip
-	except KeyError:
+	except (KeyError, StopIteration):
 		sys.exit("Make sure you are connected to a WiFi network")
 
 

--- a/pyqrshare/__init__.py
+++ b/pyqrshare/__init__.py
@@ -1,9 +1,13 @@
 import sys
+import re
 import netifaces as ni
 from flask import Flask, make_response, send_file
 import pyqrcode
 from . import fileToServe
 app = Flask(__name__, static_url_path='/')
+
+
+NET_REGEX = re.compile(r'(wlan|wlp|en)\d')
 
 
 def check_args():
@@ -17,9 +21,7 @@ def check_args():
 
 def return_wlan0_ip():
 	try:
-		wlan = next(filter(
-					lambda x: x.startswith("wlan") or x.startswith("wlp"),
-					ni.interfaces()))
+		wlan = next(filter(lambda x: NET_REGEX.match(x), ni.interfaces()))
 		ip = ni.ifaddresses(wlan)[ni.AF_INET][0]['addr']
 		return ip
 	except (KeyError, StopIteration):

--- a/pyqrshare/__init__.py
+++ b/pyqrshare/__init__.py
@@ -29,13 +29,8 @@ def generate_qr():
 
 
 @app.route('/')
-def index():	
-	
-	response = make_response(send_file(fileToServe.FINAL_PATH, attachment_filename=sys.argv[1]))
-    	response.headers['Content-Disposition'] = 'attachment'
-    	return response
 def index():
-	response.headers['Content-Disposition'] = 'attachment'
+	response = make_response(send_file(sys.argv[1], as_attachment=True))
 	return response
 
 

--- a/pyqrshare/__init__.py
+++ b/pyqrshare/__init__.py
@@ -2,11 +2,12 @@ import sys
 import netifaces as ni
 from flask import Flask, make_response, send_file
 import pyqrcode
-import fileToServe
+from . import fileToServe
 app = Flask(__name__, static_url_path='/')
 
+
 def check_args():
-	if(len(sys.argv)) == 1 :
+	if(len(sys.argv)) == 1:
 		sys.exit("Provide a file/dir path")
 	elif(len(sys.argv)) == 2:
 		fileToServe.set_file_to_serve(sys.argv[1])
@@ -21,9 +22,11 @@ def return_wlan0_ip():
 	except KeyError:
 		sys.exit("Make sure you are connected to a WiFi network")
 
+
 def generate_qr():
-		url = pyqrcode.create(str(return_wlan0_ip())+':5000')
-		return url.terminal(quiet_zone = 1)
+	url = pyqrcode.create(str(return_wlan0_ip())+':5000')
+	return url.terminal(quiet_zone=1)
+
 
 @app.route('/')
 def index():	
@@ -31,12 +34,15 @@ def index():
 	response = make_response(send_file(fileToServe.FINAL_PATH, attachment_filename=sys.argv[1]))
     	response.headers['Content-Disposition'] = 'attachment'
     	return response
+def index():
+	response.headers['Content-Disposition'] = 'attachment'
+	return response
+
+
 def main():
 	check_args()
-	print(generate_qr())
+	print((generate_qr()))
 	try:
 		app.run(host=return_wlan0_ip(), threaded = True, debug=False, use_reloader = False)
 	except:
 		sys.exit("Could not establish connection. :( ")
-
-

--- a/pyqrshare/__init__.py
+++ b/pyqrshare/__init__.py
@@ -24,7 +24,7 @@ def return_wlan0_ip():
 
 
 def generate_qr():
-	url = pyqrcode.create(str(return_wlan0_ip())+':5000')
+	url = pyqrcode.create('http://' + str(return_wlan0_ip()) + ':5000')
 	return url.terminal(quiet_zone=1)
 
 

--- a/pyqrshare/__init__.py
+++ b/pyqrshare/__init__.py
@@ -11,11 +11,11 @@ NET_REGEX = re.compile(r'(wlan|wlp|en)\d')
 
 
 def check_args():
-	if(len(sys.argv)) == 1:
+	if len(sys.argv) == 1:
 		sys.exit("Provide a file/dir path")
-	elif(len(sys.argv)) == 2:
+	elif len(sys.argv) == 2:
 		fileToServe.set_file_to_serve(sys.argv[1])
-	elif(len(sys.argv)) > 2:
+	elif len(sys.argv) > 2:
 		sys.exit("Too many arguments")
 
 

--- a/pyqrshare/command_line.py
+++ b/pyqrshare/command_line.py
@@ -1,3 +1,5 @@
 import pyqrshare
+
+
 def main():
 	pyqrshare.main()

--- a/pyqrshare/fileToServe.py
+++ b/pyqrshare/fileToServe.py
@@ -1,26 +1,26 @@
-import os,sys,zipfile,tempfile
+import sys, os, zipfile, tempfile
+
+
 FINAL_PATH = ''
+
+
 def zipdir(path, ziph):
-	for root,dir, files in os.walk(path):
+	for root, _dir, files in os.walk(path):
 		for file in files:
 			ziph.write(os.path.join(root, file))
-			
+
 
 def set_file_to_serve(path):
 	global FINAL_PATH
-	if(os.path.isfile(path)):
+	if os.path.isfile(path):
 		FINAL_PATH = path
-	elif(os.path.isdir(path)):
-		 tempdir = tempfile.mkdtemp()
-   		 temp_path = tempdir + tempdir.split('/')[1]+'.zip'
-   		 zipf = zipfile.ZipFile(temp_path, 'w', zipfile.ZIP_DEFLATED)
-    		 zipdir(path, zipf)
-   		 zipf.close()
-   		 FINAL_PATH = temp_path
-   		 return
+	elif os.path.isdir(path):
+		tempdir = tempfile.mkdtemp()
+		temp_path = tempdir + tempdir.split('/')[1]+'.zip'
+		zipf = zipfile.ZipFile(temp_path, 'w', zipfile.ZIP_DEFLATED)
+		zipdir(path, zipf)
+		zipf.close()
+		FINAL_PATH = temp_path
+		return
 	else:
 		sys.exit("Not a valid path")
-
-
-
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+blinker==1.7.0
+click==8.1.7
+Flask==3.0.0
+importlib-metadata==7.0.0
+itsdangerous==2.1.2
+Jinja2==3.1.2
+MarkupSafe==2.1.3
+netifaces==0.11.0
+pkg_resources==0.0.0
+PyQRCode==1.2.1
+Werkzeug==3.0.1
+zipp==3.17.0

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,11 @@ setup(name='pyqrshare',
       classifiers=[
         'Development Status :: Beta',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Topic :: File Sharing :: QRCode',
       ],
       entry_points = {


### PR DESCRIPTION
- Move to Python 3.x codebase:
   - Fix mixing of white-spaces and tabs that are not tolerated by modern Python 3.x distros.
   - Fix relative imports.
- Upgrade code to latest version of Flask.
- Better get IP address from Wi-Fi interface, including support to modern Mac OS machines.